### PR TITLE
Add trip.yaml card for Cable Juice Planner

### DIFF
--- a/Cable-Juice-Planner-Readme/cards/trip.yaml
+++ b/Cable-Juice-Planner-Readme/cards/trip.yaml
@@ -1,0 +1,61 @@
+# Replace <PREFIX> with the filename of the script (default is "ev")
+
+type: vertical-stack
+cards:
+  - type: custom:mushroom-title-card
+    title: Tur ladning
+  - type: conditional
+    conditions:
+      - condition: state
+        entity: input_number.<PREFIX>_trip_range_needed
+        state: '0.0'
+    card:
+      type: custom:mushroom-number-card
+      entity: input_number.<PREFIX>_trip_charge_procent
+  - type: conditional
+    conditions:
+      - condition: state
+        entity: input_number.<PREFIX>_trip_charge_procent
+        state: '0.0'
+    card:
+      type: custom:mushroom-number-card
+      entity: input_number.<PREFIX>_trip_range_needed
+  - type: custom:mushroom-entity-card
+    entity: input_boolean.<PREFIX>_trip_preheat
+    icon_color: red
+    fill_container: false
+    tap_action:
+      action: toggle
+  - type: custom:mushroom-entity-card
+    entity: input_datetime.<PREFIX>_trip_date_time
+    hold_action:
+      action: none
+    double_tap_action:
+      action: none
+  - type: custom:mushroom-entity-card
+    entity: input_datetime.<PREFIX>_trip_homecoming_date_time
+    hold_action:
+      action: none
+    double_tap_action:
+      action: none
+  - type: custom:mushroom-entity-card
+    entity: input_boolean.<PREFIX>_trip_charging
+    tap_action:
+      action: toggle
+    hold_action:
+      action: none
+    double_tap_action:
+      action: none
+  - type: custom:mushroom-chips-card
+    chips:
+      - type: entity
+        entity: input_button.<PREFIX>_trip_reset
+        content_info: name
+        tap_action:
+          action: toggle
+        hold_action:
+          action: none
+        use_entity_picture: false
+    alignment: end
+view_layout:
+  position: sidebar


### PR DESCRIPTION
This pull request adds a new card called "trip.yaml" to the Cable Juice Planner. The card includes various input fields and buttons for trip-related information, such as trip range needed, trip charge percentage, preheating, trip date and time, homecoming date and time, and charging status. This card enhances the functionality and user experience of the Cable Juice Planner.