### PR TITLE
Add files created in Home Assistant folder in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ homeassistant:
 ---
 ### Fremtiden
 - Konvertere scriptet til en integration
+
+### Filer der laves i roden af Home Assistant mappen:
+- ev_config.yaml **(Konfigurations filen)**
+- ev_charging_history_db.yaml **(Opladningshistorik database)**
+- ev_drive_efficiency_db.yaml **(Kørselseffiktivitet procent database)**
+- ev_km_kwh_efficiency_db.yaml **(Km/Kwh database)**
+- ev_kwh_avg_prices_db.yaml **(Offline strøm priser database)**
+- ev_solar_production_available_db.yaml **(Solcelle over produktion database)**
+
+
 ---
 > [!Note]
 > ### Tilføj til dette til configuration.yaml for at kunne opdatere fra Home Assistant service


### PR DESCRIPTION
This pull request adds a section to the Readme file that lists the files created in the root of the Home Assistant folder. The added files include ev_config.yaml (configuration file), ev_charging_history_db.yaml (charging history database), ev_drive_efficiency_db.yaml (driving efficiency percentage database), ev_km_kwh_efficiency_db.yaml (km/kWh database), ev_kwh_avg_prices_db.yaml (offline electricity prices database), and ev_solar_production_available_db.yaml (solar production overage database).