### PR TITLE
Add detailed README for Home Assistant cards with image links

### DIFF
--- a/cards/README.md
+++ b/cards/README.md
@@ -1,0 +1,20 @@
+> [!Note]
+> Klik på et billede nedenunder for at få Home Assistant kortet
+> | Emoji beskrivelse | Historik | Oversigt |
+> | --- | --- | --- |
+> | [![Emoji beskrivelse](../images/emoji_description.png)](../cards/emoji_description.yaml) | [![Historik](../images/history.png)](../cards/history.yaml)<br>[Virtuel batteriniveau entity](../cards/history_emulated_battery.yaml) | [![Oversigt](../images/overview.png)](../cards/overview.yaml) |
+>
+> | Uge strømpriser | Solcelleoverproduktion |
+> | --- | --- |
+> | [![Uge strømpriser](../images/week_prices.png)](../cards/week_prices.yaml) | [![Solcelleoverproduktion](../images/solar_price_graf.png)](../cards/solar_price_graf.yaml) |
+>
+> | Manuel ladning | Tur ladning |
+> | --- | --- |
+> | [![Manuel](../images/manual.png)](../cards/manual.yaml) | [![Tur](../images/trip.png)](../cards/trip.yaml) |
+>
+> | Indstillinger |  |
+> | --- | --- |
+> | [![Indstillinger](../images/settings_solar_charging.png)](../cards/settings_solar_charging.yaml) | [![Indstillinger](../images/settings_fully_charged.png)](../Readme/cards/settings_fully_charged.yaml) |
+> | [![Indstillinger](../images/settings_fill_up.png)](../cards/settings_fill_up.yaml) | [![Indstillinger](../images/settings_cheap_charging.png)](../cards/settings_cheap_charging.yaml) |
+> | [![Indstillinger](../images/settings_workplan.png)](../cards/settings_workplan.yaml) | [![Indstillinger](../images/settings_battery_level_preheat.png)](../Readme/cards/settings_battery_level_preheat.yaml) |
+> | [![Indstillinger](../images/settings_solar_sell_price.png)](../cards/settings_solar_sell_price.yaml) | [![Indstillinger](../images/settings_calculate_loss.png)](../cards/settings_calculate_loss.yaml) |


### PR DESCRIPTION
This pull request enhances the README by adding detailed descriptions and image links for various Home Assistant cards. Each card is now represented with an associated image, making it easier for users to understand their functionalities and access the corresponding YAML configurations. This improvement aims to provide clearer guidance and better usability for users interacting with Home Assistant cards.