### PR TITLE
Fix key_renaming check and use correct timestamp in fetch_history_data

### DIFF
--- a/pyscript/ev.py
+++ b/pyscript/ev.py
@@ -1275,7 +1275,7 @@ def init():
                 else:
                     old_entity_id = ".".join(old_path.split(".")[-2:])
                     new_entity_id = ".".join(new_path.split(".")[-2:])
-                    if old_entity_id in all_entities:
+                    if old_entity_id in all_entities and new_entity_id not in all_entities:
                         old_entity_id_state = get_state(old_entity_id)
                         old_entity_id_attr = get_attr(old_entity_id)
                         

--- a/pyscript/modules/history.py
+++ b/pyscript/modules/history.py
@@ -6,7 +6,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.util import dt as dt_util
 
-
 from logging import getLogger
 BASENAME = f"pyscript.modules.{__name__}"
 _LOGGER = getLogger(BASENAME)
@@ -82,7 +81,13 @@ def fetch_history_data(hass: HomeAssistant, entity_id: str, start_time: datetime
         )'''
         
     if entity_id in hist_data:
-        entity_state_dict = {d.last_reported_timestamp: d.state for d in hist_data[entity_id]}
+        #entity_state_dict = {d.last_reported_timestamp: d.state for d in hist_data[entity_id]}
+        entity_state_dict = {}
+        for d in hist_data[entity_id]:
+            try:
+                entity_state_dict[d.last_updated.timestamp()] = d.state
+            except Exception as e:
+                _LOGGER.error(f"Error in fetch_history_data: {e}")
         
         start_timestamp = datetime.datetime.timestamp(start_time)
         end_timestamp = datetime.datetime.timestamp(end_time)


### PR DESCRIPTION
This pull request includes two commits. The first commit fixes a bug in the key_renaming function by checking if the new entity_id is not in all_entities. The second commit fixes an issue caused by a Home Assistant update by using d.last_updated.timestamp() instead of d.last_reported_timestamp in the fetch_history_data function.