### PR TITLE
Update power condition in charging logic

### DIFF
--- a/pyscript/ev.py
+++ b/pyscript/ev.py
@@ -1427,7 +1427,7 @@ init()
 
 if INITIALIZATION_COMPLETE:
     solar_min_amp = CONFIG['solar']['charging_single_phase_min_amp'] if float(CONFIG['charger']['charging_phases']) > 1.0 else CONFIG['solar']['charging_three_phase_min_amp'] * 3.0
-    SOLAR_CHARGING_TRIGGER_ON = abs(CONFIG['charger']['power_voltage'] * solar_min_amp)
+    SOLAR_CHARGING_TRIGGER_ON = abs( * solar_min_amp)
     MAX_WATT_CHARGING = (CONFIG['charger']['power_voltage'] * CONFIG['charger']['charging_phases']) * CONFIG['charger']['charging_max_amp']
     MAX_KWH_CHARGING = MAX_WATT_CHARGING / 1000
 
@@ -5196,7 +5196,7 @@ def charging_without_rule():
     power = get_state(entity_id, float_type=True, error_state=0.0)
     power_avg = round(abs(float(get_average_value(entity_id, past, now, convert_to="W", error_state=0.0))), 3)
     
-    if power != 0.0 or (power > 100.0 and power_avg > 100.0):
+    if power != 0.0 or (power > CONFIG['charger']['power_voltage'] and power_avg > CONFIG['charger']['power_voltage']):
         if CHARGING_NO_RULE_COUNT > 2:
             if not CURRENT_CHARGING_SESSION['start']:
                 charging_history({'Price': get_current_hour_price(), 'Cost': 0.0, 'kWh': 0.0, 'battery_level': 0.0, 'no_rule': True}, "no_rule")


### PR DESCRIPTION
Refine the power condition in the `charging_without_rule` function to use the configured power voltage for better accuracy in charging decisions. Adjust the solar charging trigger calculation for consistency.