### PR TITLE
Fix calculation for reserved battery level in energy availability function

### DIFF
--- a/pyscript/ev.py
+++ b/pyscript/ev.py
@@ -7727,7 +7727,7 @@ def max_local_energy_available_remaining_period():
             
             discharge_above_needed = TASKS[task_names["discharge_above_needed"]].result()
             powerwall_battery_level = TASKS[task_names["powerwall_battery_level"]].result()
-            powerwall_reserved_battery_level = max(TASKS[task_names["powerwall_reserved_battery_level"]].result() - 1.0, 0.0)
+            powerwall_reserved_battery_level = max(TASKS[task_names["powerwall_reserved_battery_level"]].result(), 0.0) #max(TASKS[task_names["powerwall_reserved_battery_level"]].result() - 1.0, 0.0)
             powerwall_charging_power = TASKS[task_names["powerwall_charging_power"]].result()
             powerwall_charging_timestamps = TASKS[task_names["powerwall_charging_timestamps"]].result()
             


### PR DESCRIPTION
Adjust the calculation of the reserved battery level to ensure it does not go below zero, improving accuracy in energy availability assessments.