### PR TITLE
Fix parameter names and update Markdown hints in translation files

### DIFF
--- a/pyscript/ev.py
+++ b/pyscript/ev.py
@@ -2498,7 +2498,7 @@ def build_comment_db_yaml() -> dict:
             i18n_key,
             charger_supported_states=charger_supported_str,
             ev_supported_states=ev_supported_str,
-            modname=__name__,
+            name=__name__,
         )
     
     return COMMENT_DB_YAML

--- a/pyscript/modules/cjp_translations/da-DK.yaml
+++ b/pyscript/modules/cjp_translations/da-DK.yaml
@@ -627,10 +627,10 @@ ui:
 
   emoji_description:
     header: "Emoji beskrivelse"
-    markdown_hint: "Brug Markdown kort med dette i: {{{{ states.sensor.{name}_emoji_description.attributes.description }}}}"
+    markdown_hint: "Brug Markdown kort med dette i: {{ states.sensor.{name}_emoji_description.attributes.description }}"
 
   set_default_entity_states:
-    markdown_guide: "Brug Markdown kort med dette i: {{{{ states.sensor.{name}_overview.attributes.overview }}}}"
+    markdown_guide: "Brug Markdown kort med dette i: {{ states.sensor.{name}_overview.attributes.overview }}"
     no_overview: "Ingen oversigt endnu"
 
   drive_efficiency:
@@ -639,7 +639,7 @@ ui:
     used: "Brugt"
 
   load_charging_history:
-    default_state: "Brug Markdown kort med dette i: {{{{ states.sensor.{__name__}_charging_history.attributes.history }}}}"
+    default_state: "Brug Markdown kort med dette i: {{ states.sensor.{__name__}_charging_history.attributes.history }}"
 
   charging_history_combine_and_set:
     too_big_warning: "Home Assistant tillader ikke at vise mere historik"

--- a/pyscript/modules/cjp_translations/de-DE.yaml
+++ b/pyscript/modules/cjp_translations/de-DE.yaml
@@ -605,10 +605,10 @@ ui:
 
   emoji_description:
     header: "Emoji-Beschreibung"
-    markdown_hint: "Markdown-Karte verwenden mit: {{{{ states.sensor.{name}_emoji_description.attributes.description }}}}"
+    markdown_hint: "Markdown-Karte verwenden mit: {{ states.sensor.{name}_emoji_description.attributes.description }}"
 
   set_default_entity_states:
-    markdown_guide: "Markdown-Karte verwenden mit: {{{{ states.sensor.{name}_overview.attributes.overview }}}}"
+    markdown_guide: "Markdown-Karte verwenden mit: {{ states.sensor.{name}_overview.attributes.overview }}"
     no_overview: "Noch keine Übersicht"
 
   drive_efficiency:
@@ -617,7 +617,7 @@ ui:
     used: "Verbraucht"
 
   load_charging_history:
-    default_state: "Markdown-Karte verwenden mit: {{{{ states.sensor.{__name__}_charging_history.attributes.history }}}}"
+    default_state: "Markdown-Karte verwenden mit: {{ states.sensor.{__name__}_charging_history.attributes.history }}"
 
   charging_history_combine_and_set:
     too_big_warning: "Home Assistant kann nicht mehr Historie anzeigen"

--- a/pyscript/modules/cjp_translations/en-GB.yaml
+++ b/pyscript/modules/cjp_translations/en-GB.yaml
@@ -605,10 +605,10 @@ ui:
 
   emoji_description:
     header: "Emoji description"
-    markdown_hint: "Use Markdown card with: {{{{ states.sensor.{name}_emoji_description.attributes.description }}}}"
+    markdown_hint: "Use Markdown card with: {{ states.sensor.{name}_emoji_description.attributes.description }}"
 
   set_default_entity_states:
-    markdown_guide: "Use Markdown card with: {{{{ states.sensor.{name}_overview.attributes.overview }}}}"
+    markdown_guide: "Use Markdown card with: {{ states.sensor.{name}_overview.attributes.overview }}"
     no_overview: "No overview yet"
 
   drive_efficiency:
@@ -617,7 +617,7 @@ ui:
     used: "Used"
 
   load_charging_history:
-    default_state: "Use Markdown card with: {{{{ states.sensor.{__name__}_charging_history.attributes.history }}}}"
+    default_state: "Use Markdown card with: {{ states.sensor.{__name__}_charging_history.attributes.history }}"
 
   charging_history_combine_and_set:
     too_big_warning: "Home Assistant cannot display more history"

--- a/pyscript/modules/cjp_translations/en-US.yaml
+++ b/pyscript/modules/cjp_translations/en-US.yaml
@@ -624,10 +624,10 @@ ui:
 
   emoji_description:
     header: "Emoji description"
-    markdown_hint: "Use a Markdown card with: {{{{ states.sensor.{name}_emoji_description.attributes.description }}}}"
+    markdown_hint: "Use a Markdown card with: {{ states.sensor.{name}_emoji_description.attributes.description }}"
 
   set_default_entity_states:
-    markdown_guide: "Use a Markdown card with: {{{{ states.sensor.{name}_overview.attributes.overview }}}}"
+    markdown_guide: "Use a Markdown card with: {{ states.sensor.{name}_overview.attributes.overview }}"
     no_overview: "No overview yet"
 
   drive_efficiency:
@@ -636,7 +636,7 @@ ui:
     used: "Used"
 
   load_charging_history:
-    default_state: "Use a Markdown card with: {{{{ states.sensor.{__name__}_charging_history.attributes.history }}}}"
+    default_state: "Use a Markdown card with: {{ states.sensor.{__name__}_charging_history.attributes.history }}"
 
   charging_history_combine_and_set:
     too_big_warning: "Home Assistant cannot display more history"

--- a/pyscript/modules/cjp_translations/pl-PL.yaml
+++ b/pyscript/modules/cjp_translations/pl-PL.yaml
@@ -613,10 +613,10 @@ ui:
 
   emoji_description:
     header: "Opis emoji"
-    markdown_hint: "Użyj karty Markdown z: {{{{ states.sensor.{name}_emoji_description.attributes.description }}}}"
+    markdown_hint: "Użyj karty Markdown z: {{ states.sensor.{name}_emoji_description.attributes.description }}"
 
   set_default_entity_states:
-    markdown_guide: "Użyj karty Markdown z: {{{{ states.sensor.{name}_overview.attributes.overview }}}}"
+    markdown_guide: "Użyj karty Markdown z: {{ states.sensor.{name}_overview.attributes.overview }}"
     no_overview: "Brak przeglądu"
 
   drive_efficiency:
@@ -625,7 +625,7 @@ ui:
     used: "Zużyto"
 
   load_charging_history:
-    default_state: "Użyj karty Markdown z: {{{{ states.sensor.{__name__}_charging_history.attributes.history }}}}"
+    default_state: "Użyj karty Markdown z: {{ states.sensor.{__name__}_charging_history.attributes.history }}"
 
   charging_history_combine_and_set:
     too_big_warning: "Home Assistant nie może wyświetlić większej historii"

--- a/pyscript/modules/cjp_translations/uk-UA.yaml
+++ b/pyscript/modules/cjp_translations/uk-UA.yaml
@@ -609,10 +609,10 @@ ui:
 
   emoji_description:
     header: "Опис emoji"
-    markdown_hint: "Використайте картку Markdown з: {{{{ states.sensor.{name}_emoji_description.attributes.description }}}}"
+    markdown_hint: "Використайте картку Markdown з: {{ states.sensor.{name}_emoji_description.attributes.description }}"
 
   set_default_entity_states:
-    markdown_guide: "Картка Markdown з: {{{{ states.sensor.{name}_overview.attributes.overview }}}}"
+    markdown_guide: "Картка Markdown з: {{ states.sensor.{name}_overview.attributes.overview }}"
     no_overview: "Поки що немає огляду"
 
   drive_efficiency:
@@ -621,7 +621,7 @@ ui:
     used: "Використано"
 
   load_charging_history:
-    default_state: "Картка Markdown з: {{{{ states.sensor.{__name__}_charging_history.attributes.history }}}}"
+    default_state: "Картка Markdown з: {{ states.sensor.{__name__}_charging_history.attributes.history }}"
 
   charging_history_combine_and_set:
     too_big_warning: "Home Assistant не може показати більше історії"

--- a/pyscript/modules/filesystem.py
+++ b/pyscript/modules/filesystem.py
@@ -7,7 +7,7 @@ import re
 import textwrap
 import sys, os, os.path, tempfile
 
-from typing import Optional, Dict, Any
+from typing import Any, Dict, List, Optional, Union
 
 _FILE_LOCKS: Dict[str, asyncio.Lock] = {}
 
@@ -305,10 +305,10 @@ async def load_yaml(filename: Optional[str] = None, retries: int = 10, sleep_sec
 
 async def save_yaml(
     filename: Optional[str] = None,
-    db: Optional[Dict[str, Any]] = None,
+    db: Optional[Union[Dict[str, Any], List[Any]]] = None,
     comment_db: Optional[Dict[str, str]] = None,
     max_width: int = 120,
-):
+) -> bool:
     """
     Save a dictionary as YAML safely and atomically, with optional inline comments.
     
@@ -326,8 +326,8 @@ async def save_yaml(
     try:
         if db is None:
             raise ValueError("db must not be None")
-        if not isinstance(db, dict):
-            raise TypeError("db must be a dict")
+        if not isinstance(db, (dict, list)):
+            raise TypeError("db must be a dict or list")
         if comment_db is not None and not isinstance(comment_db, dict):
             raise TypeError("comment_db must be a dict or None")
 


### PR DESCRIPTION
Rename a parameter in the `build_comment_db_yaml` function for clarity, update Markdown hints in translation files to remove unnecessary braces, and modify the type hint for the `db` parameter in the `save_yaml` function to accept both dictionaries and lists.