### PR TITLE
Return 0.0 for filtered values in get_specific_values function

### DIFF
--- a/pyscript/modules/utils.py
+++ b/pyscript/modules/utils.py
@@ -161,6 +161,7 @@ def get_specific_values(values, positive_only = False, negative_only = False):
                 continue
             
             if (negative_only and value > 0.0) or (positive_only and value < 0.0):
+                return_list.append(0.0)
                 continue
             
             return_list.append(value)


### PR DESCRIPTION
Adjust the `get_specific_values` function to return 0.0 for values filtered by the `positive_only` or `negative_only` parameters.