### PR TITLE
Add EV configuration check to charging session function

### DIFF
--- a/pyscript/ev.py
+++ b/pyscript/ev.py
@@ -4144,6 +4144,9 @@ def get_public_charging_session_done():
     func_name = "get_public_charging_session_done"
     _LOGGER = globals()['_LOGGER'].getChild(func_name)
     
+    if not is_ev_configured():
+        return False
+    
     state = "unknown"
     try:
         state = get_state(f"binary_sensor.{__name__}_public_charging_session_done", error_state="unknown")


### PR DESCRIPTION
Implement a check for EV configuration in the `get_public_charging_session_done` function to ensure proper functionality.